### PR TITLE
Coracle set result fix

### DIFF
--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -226,8 +226,12 @@ const syncOracleResultVoted = async (currentBlockNum) => {
             }
 
             // Update Oracle balance
-            oracle.amounts[vote.optionIdx] = new BigNumber(oracle.amounts[vote.optionIdx]).plus(voteBn).toString(10);
-            await DBHelper.updateObjectByQuery(db.Oracles, { address: oracle.address }, { amounts: oracle.amounts });
+            // Check for token match first because we don't want to increment the COracle's amounts with the Set Result
+            // BOT. Setting the result creates an OracleResultVoted event and takes place in the COracle contract.
+            if (oracle.token === vote.token) {
+              oracle.amounts[vote.optionIdx] = new BigNumber(oracle.amounts[vote.optionIdx]).plus(voteBn).toString(10);
+              await DBHelper.updateObjectByQuery(db.Oracles, { address: oracle.address }, { amounts: oracle.amounts });
+            }
 
             resolve();
           } catch (err) {

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -5,7 +5,7 @@ const { BigNumber } = require('bignumber.js');
 
 const updateTransactions = require('./update-transactions');
 const { getInstance } = require('../qclient');
-const { TOKEN, WITHDRAW_TYPE } = require('../constants');
+const { TOKEN, STATUS, WITHDRAW_TYPE } = require('../constants');
 const { getContractMetadata } = require('../config');
 const { db } = require('../db');
 const DBHelper = require('../db/db-helper');
@@ -277,7 +277,7 @@ const syncOracleResultSet = async (currentBlockNum) => {
             // Update Oracle status
             await db.Oracles.update(
               { address: resultSet.oracleAddress },
-              { $set: { resultIdx: resultSet.resultIdx, status: 'PENDING' } }, {},
+              { $set: { resultIdx: resultSet.resultIdx, status: STATUS.PENDING } }, {},
             );
             resolve();
           } catch (err) {
@@ -319,11 +319,11 @@ const syncFinalResultSet = async (currentBlockNum) => {
             // Update statuses to withdraw
             await db.Topics.update(
               { address: finalResultSet.topicAddress },
-              { $set: { resultIdx: finalResultSet.resultIdx, status: 'WITHDRAW' } },
+              { $set: { resultIdx: finalResultSet.resultIdx, status: STATUS.WITHDRAW } },
             );
             await db.Oracles.update(
               { topicAddress: finalResultSet.topicAddress },
-              { $set: { status: 'WITHDRAW' } }, { multi: true },
+              { $set: { status: STATUS.WITHDRAW } }, { multi: true },
             );
 
             resolve();
@@ -416,8 +416,8 @@ const syncEscrowWithdrawn = async (currentBlockNum) => {
 const updateOraclesDoneVoting = async (currentBlockTime) => {
   try {
     await db.Oracles.update(
-      { endTime: { $lt: currentBlockTime }, status: 'VOTING' },
-      { $set: { status: 'WAITRESULT' } },
+      { endTime: { $lt: currentBlockTime }, status: STATUS.VOTING },
+      { $set: { status: STATUS.WAITRESULT } },
       { multi: true },
     );
   } catch (err) {
@@ -429,8 +429,8 @@ const updateOraclesDoneVoting = async (currentBlockTime) => {
 const updateCOraclesDoneResultSet = async (currentBlockTime) => {
   try {
     await db.Oracles.update(
-      { resultSetEndTime: { $lt: currentBlockTime }, token: TOKEN.QTUM, status: 'WAITRESULT' },
-      { $set: { status: 'OPENRESULTSET' } },
+      { resultSetEndTime: { $lt: currentBlockTime }, token: TOKEN.QTUM, status: STATUS.WAITRESULT },
+      { $set: { status: STATUS.OPENRESULTSET } },
       { multi: true },
     );
   } catch (err) {

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -5,7 +5,7 @@ const { BigNumber } = require('bignumber.js');
 
 const updateTransactions = require('./update-transactions');
 const { getInstance } = require('../qclient');
-const { WITHDRAW_TYPE } = require('../constants');
+const { TOKEN, WITHDRAW_TYPE } = require('../constants');
 const { getContractMetadata } = require('../config');
 const { db } = require('../db');
 const DBHelper = require('../db/db-helper');
@@ -200,7 +200,7 @@ const syncOracleResultVoted = async (currentBlockNum) => {
             const voteBn = new BigNumber(vote.amount);
             const topic = await DBHelper.findOne(db.Topics, { address: oracle.topicAddress });
             switch (vote.token) {
-              case 'QTUM': {
+              case TOKEN.QTUM: {
                 topic.qtumAmount[vote.optionIdx] =
                   new BigNumber(topic.qtumAmount[vote.optionIdx]).plus(voteBn).toString(10);
                 await DBHelper.updateObjectByQuery(
@@ -210,7 +210,7 @@ const syncOracleResultVoted = async (currentBlockNum) => {
                 );
                 break;
               }
-              case 'BOT': {
+              case TOKEN.BOT: {
                 topic.botAmount[vote.optionIdx] =
                   new BigNumber(topic.botAmount[vote.optionIdx]).plus(voteBn).toString(10);
                 await DBHelper.updateObjectByQuery(
@@ -429,7 +429,7 @@ const updateOraclesDoneVoting = async (currentBlockTime) => {
 const updateCOraclesDoneResultSet = async (currentBlockTime) => {
   try {
     await db.Oracles.update(
-      { resultSetEndTime: { $lt: currentBlockTime }, token: 'QTUM', status: 'WAITRESULT' },
+      { resultSetEndTime: { $lt: currentBlockTime }, token: TOKEN.QTUM, status: 'WAITRESULT' },
       { $set: { status: 'OPENRESULTSET' } },
       { multi: true },
     );


### PR DESCRIPTION
Found a critical bug when adding to the `amounts` field for COracles. This fixes: https://github.com/bodhiproject/bodhi-ui/issues/1006

The issue was Set Results emit the `OracleResultVote` event so the server was adding the set result amount to the COracle's amounts field.