### PR TITLE
Fix multiple filter not working

### DIFF
--- a/src/graphql/queries/events.js
+++ b/src/graphql/queries/events.js
@@ -36,10 +36,11 @@ const buildFilters = ({
   if (status) filter.status = status;
   if (language) filter.language = language;
 
-  let filters = filter ? [filter] : [];
+  let filters = Object.keys(filter).length !== 0 ? [filter] : [];
   for (let i = 0; i < OR.length; i++) {
     filters = filters.concat(buildFilters(OR[i]));
   }
+
   return filters;
 };
 


### PR DESCRIPTION
`let filters = filter ? [filter] : [];`
When filter is `{}`, filters always add a `{}` into the whole filter, which will query all event