### PR TITLE
Transaction Loadmore

### DIFF
--- a/src/graphql/queries/transactions.js
+++ b/src/graphql/queries/transactions.js
@@ -64,30 +64,37 @@ module.exports = async (
 ) => {
   const txFilters = buildTxFilters(lowercaseFilters(filter));
   const orderBy = { blockNum: -1 };
-
+  let totalCount = 0;
   // Run Events query
-  let cursor = Events.cfind(buildEventFilters(txFilters));
+  const eventFilter = buildEventFilters(txFilters);
+  totalCount += await Events.count(eventFilter);
+  let cursor = Events.cfind(eventFilter);
   cursor = buildCursorOptions(cursor, orderBy, limit);
   const events = await cursor.exec();
 
   // Run Bets query
-  cursor = Bets.cfind(buildBetFilters(txFilters));
+  const betFilter = buildBetFilters(txFilters);
+  totalCount += await Bets.count(betFilter);
+  cursor = Bets.cfind(betFilter);
   cursor = buildCursorOptions(cursor, orderBy, limit);
   const bets = await cursor.exec();
 
   // Run ResultSets query
-  cursor = ResultSets.cfind(buildResultSetFilters(txFilters));
+  const resultSetFilter = buildResultSetFilters(txFilters);
+  totalCount += await ResultSets.count(resultSetFilter);
+  cursor = ResultSets.cfind(resultSetFilter);
   cursor = buildCursorOptions(cursor, orderBy, limit);
   const resultSets = await cursor.exec();
 
   // Run Withdraws query
-  cursor = Withdraws.cfind(buildWithdrawFilters(txFilters));
+  const withdrawFilter = buildWithdrawFilters(txFilters);
+  totalCount += await Withdraws.count(withdrawFilter);
+  cursor = Withdraws.cfind(withdrawFilter);
   cursor = buildCursorOptions(cursor, orderBy, limit);
   const withdraws = await cursor.exec();
 
   // Combine to single list
   let txs = concat(events, bets, resultSets, withdraws);
-  const totalCount = txs.length;
 
   // Order list by blockNum
   txs = order(txs, ['blockNum'], [ORDER_DIRECTION.DESCENDING.toLowerCase()]);

--- a/src/graphql/queries/transactions.js
+++ b/src/graphql/queries/transactions.js
@@ -59,7 +59,7 @@ const buildWithdrawFilters = ({
 
 module.exports = async (
   root,
-  { filter, limit = 10, skip = 0, skips: { eventSkip, betSkip, resultSetSkip, withdrawSkip } },
+  { filter, limit = 10, skip = 0, transactionSkips: { eventSkip, betSkip, resultSetSkip, withdrawSkip } },
   { db: { Events, Bets, ResultSets, Withdraws } },
 ) => {
   const txFilters = buildTxFilters(lowercaseFilters(filter));
@@ -103,7 +103,7 @@ module.exports = async (
   txs = slice(txs, 0, limit);
 
   const pageInfo = constructPageInfo(limit, skip, totalCount);
-  pageInfo.nextSkips = {
+  pageInfo.nextTransactionSkips = {
     nextEventSkip: eventSkip + txs.filter(tx => tx.txType === TX_TYPE.CREATE_EVENT).length,
     nextBetSkip: betSkip + txs.filter(tx => tx.txType === TX_TYPE.BET
                                         || tx.txType === TX_TYPE.VOTE).length,

--- a/src/graphql/queries/transactions.js
+++ b/src/graphql/queries/transactions.js
@@ -63,7 +63,7 @@ module.exports = async (
   { db: { Events, Bets, ResultSets, Withdraws } },
 ) => {
   const txFilters = buildTxFilters(lowercaseFilters(filter));
-  const orderBy = { blockNum: -1 };
+  const orderBy = [{ field: 'blockNum', direction: ORDER_DIRECTION.DESCENDING }];
   let totalCount = 0;
   // Run Events query
   const eventFilter = buildEventFilters(txFilters);
@@ -100,8 +100,7 @@ module.exports = async (
   txs = order(txs, ['blockNum'], [ORDER_DIRECTION.DESCENDING.toLowerCase()]);
 
   // Slice list
-  const end = Math.min(skip + limit, txs.length);
-  txs = slice(txs, skip, end);
+  txs = slice(txs, 0, limit);
 
   const pageInfo = constructPageInfo(limit, skip, totalCount);
   pageInfo.nextSkips = {

--- a/src/graphql/queries/utils.js
+++ b/src/graphql/queries/utils.js
@@ -67,9 +67,6 @@ const buildCursorOptions = (cursor, orderBy, limit, skip) => {
 const constructPageInfo = (limit, skip, totalCount) => {
   if (!isNumber(limit) || !isNumber(skip)) return undefined;
 
-  console.log(limit);
-  console.log(skip);
-  console.log(totalCount);
   const end = skip + limit;
   const hasNextPage = end < totalCount;
   const pageNumber = toInteger(end / limit);

--- a/src/graphql/queries/utils.js
+++ b/src/graphql/queries/utils.js
@@ -67,6 +67,9 @@ const buildCursorOptions = (cursor, orderBy, limit, skip) => {
 const constructPageInfo = (limit, skip, totalCount) => {
   if (!isNumber(limit) || !isNumber(skip)) return undefined;
 
+  console.log(limit);
+  console.log(skip);
+  console.log(totalCount);
   const end = skip + limit;
   const hasNextPage = end < totalCount;
   const pageNumber = toInteger(end / limit);

--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -159,6 +159,10 @@ module.exports = {
       const event = await DBHelper.findOneEvent({ address: eventAddress });
       return event && event.results[resultIndex];
     },
+    eventName: async ({ eventAddress }) => {
+      const event = await DBHelper.findOneEvent({ address: eventAddress });
+      return event && event.name;
+    },
   },
 
   ResultSet: {
@@ -169,12 +173,20 @@ module.exports = {
       const event = await DBHelper.findOneEvent({ address: eventAddress });
       return event && event.results[resultIndex];
     },
+    eventName: async ({ eventAddress }) => {
+      const event = await DBHelper.findOneEvent({ address: eventAddress });
+      return event && event.name;
+    },
   },
 
   Withdraw: {
     txReceipt: async ({ txid }) =>
       DBHelper.findOneTransactionReceipt({ transactionHash: txid }),
     block: async ({ blockNum }) => DBHelper.findOneBlock({ blockNum }),
+    eventName: async ({ eventAddress }) => {
+      const event = await DBHelper.findOneEvent({ address: eventAddress });
+      return event && event.name;
+    },
   },
 };
 /* eslint-enable object-curly-newline */

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -135,6 +135,7 @@ type Bet implements Transaction {
   amount: String!
   eventRound: Int!
   resultName: String
+  eventName: String
 }
 
 type PaginatedBets {
@@ -158,6 +159,7 @@ type ResultSet implements Transaction {
   nextConsensusThreshold: String
   nextArbitrationEndTime: Int
   resultName: String
+  eventName: String
 }
 
 type PaginatedResultSets {
@@ -177,6 +179,7 @@ type Withdraw implements Transaction {
   winnerAddress: String!
   winningAmount: String!
   escrowWithdrawAmount: String!
+  eventName: String
 }
 
 type PaginatedWithdraws {

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -66,10 +66,10 @@ type PageInfo {
   hasNextPage: Boolean!
   pageNumber: Int!
   count: Int!
-  nextSkips: NextSkips
+  nextTransactionSkips: NextTransactionSkips
 }
 
-type NextSkips {
+type NextTransactionSkips {
   nextEventSkip: Int!
   nextBetSkip: Int!
   nextResultSetSkip: Int!
@@ -298,7 +298,7 @@ input TotalResultBetsFilter {
   betterAddress: String
 }
 
-input TransactionSkip {
+input TransactionSkips {
   eventSkip: Int!
   betSkip: Int!
   resultSetSkip: Int!
@@ -357,7 +357,7 @@ type Query {
     filter: TransactionFilter
     limit: Int
     skip: Int
-    skips: TransactionSkip
+    transactionSkips: TransactionSkips
   ): PaginatedTransactions!
 
   syncInfo: SyncInfo!

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -66,6 +66,14 @@ type PageInfo {
   hasNextPage: Boolean!
   pageNumber: Int!
   count: Int!
+  nextSkips: NextSkips
+}
+
+type NextSkips {
+  nextEventSkip: Int!
+  nextBetSkip: Int!
+  nextResultSetSkip: Int!
+  nextWithdrawSkip: Int!
 }
 
 type MultipleResultsEvent implements Transaction {
@@ -290,6 +298,13 @@ input TotalResultBetsFilter {
   betterAddress: String
 }
 
+input TransactionSkip {
+  eventSkip: Int!
+  betSkip: Int!
+  resultSetSkip: Int!
+  withdrawSkip: Int!
+}
+
 type Query {
   events(
     filter: EventFilter
@@ -342,6 +357,7 @@ type Query {
     filter: TransactionFilter
     limit: Int
     skip: Int
+    skips: TransactionSkip
   ): PaginatedTransactions!
 
   syncInfo: SyncInfo!


### PR DESCRIPTION
#205 

So since we are changing the history table into something like twitter notification, we need to implement transaction history `loadmore` to make it elegent instead of pull 500 entries at one time.

I'm passing a `skip` parameter for each db when querying `transaction`, and return the `nextSkip` so that the UI know where to query the next time.

We cannot use a general skip, for example:
we want to get 20 txs, so we query `20 events`, `20 bets`, `20 resultsets`, `20 withdraws`, and then we only take 20 items from all of them. If the skip is not specific for each db, some items will be missed on the next query starting from the general skip.

If we don't make a generic transaction table, this is the best solution I can come up with.
