### PR TITLE
Remove unique when index transactionReceipts table

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -44,7 +44,6 @@ const initDB = async () => {
     await db.Bets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.ResultSets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.Withdraws.ensureIndex({ fieldName: 'txid', unique: true });
-    // await db.TransactionReceipts.ensureIndex({ fieldName: 'transactionHash', unique: true });
 
     if (process.env.TEST_ENV !== 'true') {
       await applyMigrations();

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -44,7 +44,7 @@ const initDB = async () => {
     await db.Bets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.ResultSets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.Withdraws.ensureIndex({ fieldName: 'txid', unique: true });
-    await db.TransactionReceipts.ensureIndex({ fieldName: 'transactionHash', unique: true });
+    // await db.TransactionReceipts.ensureIndex({ fieldName: 'transactionHash', unique: true });
 
     if (process.env.TEST_ENV !== 'true') {
       await applyMigrations();

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -44,6 +44,7 @@ const initDB = async () => {
     await db.Bets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.ResultSets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.Withdraws.ensureIndex({ fieldName: 'txid', unique: true });
+    await db.TransactionReceipts.ensureIndex({ fieldName: 'transactionHash' });
 
     if (process.env.TEST_ENV !== 'true') {
       await applyMigrations();


### PR DESCRIPTION
if we index transactionRecipt based on txid

ERROR DB load Error: Can't insert key 0xb296dd8bb6509f4fefe746f47c3d497d5f553c72d0b1fd2f8c000ae39e3ffd7f, it violates the unique constraint 
(node:34481) UnhandledPromiseRejectionWarning: Error: Can't insert key 0xb296dd8bb6509f4fefe746f47c3d497d5f553c72d0b1fd2f8c000ae39e3ffd7f, it violates the unique constraint
    at _AVLTree.insert (/Users/bodhi/bodhi/bodhi-server/node_modules/binary-search-tree/lib/avltree.js:273:19)
    at AVLTree.insert (/Users/bodhi/bodhi/bodhi-server/node_modules/binary-search-tree/lib/avltree.js:307:27)
    at Index.insert (/Users/bodhi/bodhi/bodhi-server/node_modules/nedb/lib/indexes.js:77:15)
    at Index.insertMultipleDocs (/Users/bodhi/bodhi/bodhi-server/node_modules/nedb/lib/indexes.js:114:12)
    at Index.insert (/Users/bodhi/bodhi/bodhi-server/node_modules/nedb/lib/indexes.js:69:33)
    at Datastore.ensureIndex (/Users/bodhi/bodhi/bodhi-server/node_modules/nedb/lib/datastore.js:139:37)
    at eval (eval at thenify (/Users/bodhi/bodhi/bodhi-server/node_modules/thenify/index.js:17:10), <anonymous>:10:12)
    at new Promise (<anonymous>)
    at Object.eval [as ensureIndex] (eval at thenify (/Users/bodhi/bodhi/bodhi-server/node_modules/thenify/index.js:17:10), <anonymous>:8:8)
    at initDB (/Users/bodhi/bodhi/bodhi-server/src/db/index.js:50:34)
    at <anonymous>
(node:34481) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:34481) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.