### PR TITLE
Leaderboard table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -991,6 +991,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "async": "^3.0.1",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
+    "bignumber.js": "^9.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "crypto-random-string": "^3.0.1",

--- a/src/db/db-helper.js
+++ b/src/db/db-helper.js
@@ -440,4 +440,73 @@ module.exports = class DBHelper {
       throw err;
     }
   }
+
+  /* EventLeaderboard */
+  static async findEventLeaderboard(query, sort) {
+    try {
+      if (sort) return db.EventLeaderboard.cfind(query).sort(sort).exec();
+      return db.EventLeaderboard.find(query);
+    } catch (err) {
+      logger.error(`FIND EventLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async findOneEventLeaderboard(query) {
+    try {
+      return db.EventLeaderboard.findOne(query);
+    } catch (err) {
+      logger.error(`FINDONE EventLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async countEventLeaderboard(query) {
+    try {
+      return db.EventLeaderboard.count(query);
+    } catch (err) {
+      logger.error(`COUNT EventLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async insertEventLeaderboard(entry) {
+    try {
+      const existing = await DBHelper.findOneEventLeaderboard({
+        userAddress: entry.userAddress,
+        eventAddress: entry.eventAddress,
+      });
+      if (isNull(existing)) {
+        await db.EventLeaderboard.insert(entry);
+      } else {
+        await DBHelper.updateEventLeaderboard(existing, entry);
+      }
+    } catch (err) {
+      logger.error(`INSERT EventLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async updateEventLeaderboard(existing, entry) {
+    const investments = existing.investments + entry.investments;
+    const winnings = existing.winnings + entry.winnings;
+    try {
+      await db.EventLeaderboard.update(
+        {
+          userAddress: entry.userAddress,
+          eventAddress: entry.eventAddress,
+        },
+        {
+          $set: {
+            investments,
+            winnings,
+            returnRatio: winnings / investments,
+          },
+        },
+      );
+    } catch (err) {
+      logger.error(`UPDATE EventLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
 };

--- a/src/db/db-helper.js
+++ b/src/db/db-helper.js
@@ -509,4 +509,67 @@ module.exports = class DBHelper {
       throw err;
     }
   }
+
+  /* GlobalLeaderboard */
+  static async findGlobalLeaderboard(query, sort) {
+    try {
+      if (sort) return db.GlobalLeaderboard.cfind(query).sort(sort).exec();
+      return db.GlobalLeaderboard.find(query);
+    } catch (err) {
+      logger.error(`FIND GlobalLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async findOneGlobalLeaderboard(query) {
+    try {
+      return db.GlobalLeaderboard.findOne(query);
+    } catch (err) {
+      logger.error(`FINDONE GlobalLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async countGlobalLeaderboard(query) {
+    try {
+      return db.GlobalLeaderboard.count(query);
+    } catch (err) {
+      logger.error(`COUNT GlobalLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async insertGlobalLeaderboard(entry) {
+    try {
+      const existing = await DBHelper.findOneGlobalLeaderboard({ userAddress: entry.userAddress });
+      if (isNull(existing)) {
+        await db.GlobalLeaderboard.insert(entry);
+      } else {
+        await DBHelper.updateGlobalLeaderboard(existing, entry);
+      }
+    } catch (err) {
+      logger.error(`INSERT GlobalLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
+
+  static async updateGlobalLeaderboard(existing, entry) {
+    const investments = existing.investments + entry.investments;
+    const winnings = existing.winnings + entry.winnings;
+    try {
+      await db.GlobalLeaderboard.update(
+        { userAddress: entry.userAddress },
+        {
+          $set: {
+            investments,
+            winnings,
+            returnRatio: winnings / investments,
+          },
+        },
+      );
+    } catch (err) {
+      logger.error(`UPDATE GlobalLeaderboard error: ${err.message}`);
+      throw err;
+    }
+  }
 };

--- a/src/db/db-helper.js
+++ b/src/db/db-helper.js
@@ -3,6 +3,7 @@ const logger = require('../utils/logger');
 const { isDefined } = require('../utils');
 const { EVENT_STATUS, TX_STATUS } = require('../constants');
 const { db } = require('.');
+const web3 = require('../web3');
 
 module.exports = class DBHelper {
   /* Blocks */
@@ -488,8 +489,10 @@ module.exports = class DBHelper {
   }
 
   static async updateEventLeaderboard(existing, entry) {
-    const investments = existing.investments + entry.investments;
-    const winnings = existing.winnings + entry.winnings;
+    const existingInvest = web3.utils.toBN(existing.investments);
+    const investments = existingInvest.add(web3.utils.toBN(entry.investments)).toString(10);
+    const existingWin = web3.utils.toBN(existing.winnings);
+    const winnings = existingWin.add(web3.utils.toBN(entry.winnings)).toString(10);
     try {
       await db.EventLeaderboard.update(
         {
@@ -554,8 +557,10 @@ module.exports = class DBHelper {
   }
 
   static async updateGlobalLeaderboard(existing, entry) {
-    const investments = existing.investments + entry.investments;
-    const winnings = existing.winnings + entry.winnings;
+    const existingInvest = web3.utils.toBN(existing.investments);
+    const investments = existingInvest.add(web3.utils.toBN(entry.investments)).toString(10);
+    const existingWin = web3.utils.toBN(existing.winnings);
+    const winnings = existingWin.add(web3.utils.toBN(entry.winnings)).toString(10);
     try {
       await db.GlobalLeaderboard.update(
         { userAddress: entry.userAddress },

--- a/src/db/db-helper.js
+++ b/src/db/db-helper.js
@@ -5,7 +5,6 @@ const { sumBN } = require('../utils/web3-utils');
 const { EVENT_STATUS, TX_STATUS } = require('../constants');
 const { db } = require('.');
 const web3 = require('../web3');
-const MultipleResultsEventApi = require('../api/multiple-results-event');
 const EventLeaderboard = require('../models/event-leaderboard');
 const GlobalLeaderboard = require('../models/global-leaderboard');
 
@@ -259,75 +258,9 @@ module.exports = class DBHelper {
           returnUpdatedDocs: true,
         },
       );
-      await DBHelper.updateLeaderboardWithdrawing(updatedEvents);
+      return updatedEvents;
     } catch (err) {
       logger.error(`UPDATE Event Status Withdrawing error: ${err.message}`);
-      throw err;
-    }
-  }
-
-  static async updateLeaderboardWithdrawing(events) {
-    try {
-      each(events, async (event) => {
-        // get all the participants
-        const bets = await DBHelper.findBet({ eventAddress: event.address });
-        const filtered = [];
-        each(bets, (bet) => {
-          if (!find(filtered, {
-            eventAddress: bet.eventAddress,
-            betterAddress: bet.betterAddress,
-          })) {
-            filtered.push(bet);
-          }
-        });
-        // calculate winnings for all participants
-        const promises = [];
-        const winnings = [];
-        each(filtered, (bet) => {
-          promises.push(new Promise(async (resolve, reject) => {
-            try {
-              const { eventAddress, betterAddress } = bet;
-              const res = await MultipleResultsEventApi.calculateWinnings({
-                eventAddress,
-                address: betterAddress,
-              });
-              winnings.push({
-                eventAddress,
-                betterAddress,
-                amount: res.toString(10),
-              });
-              resolve();
-            } catch (err) {
-              reject(err);
-            }
-          }));
-        });
-        await Promise.all(promises);
-        // update leaderboard
-        each(winnings, async (winning) => {
-          // update event leaderboard winnings
-          const eventLeaderboardEntry = new EventLeaderboard({
-            eventAddress: winning.eventAddress,
-            userAddress: winning.betterAddress,
-            investments: 0,
-            winnings: winning.amount,
-          });
-          await DBHelper.insertEventLeaderboard(eventLeaderboardEntry);
-          // update global leaderboard investments, winnings
-          const userAmountInEvent = await DBHelper.findOneEventLeaderboard({
-            eventAddress: winning.eventAddress,
-            userAddress: winning.betterAddress,
-          });
-          const globalLeaderboard = new GlobalLeaderboard({
-            userAddress: winning.betterAddress,
-            investments: userAmountInEvent.investments,
-            winnings: winning.amount,
-          });
-          await DBHelper.insertGlobalLeaderboard(globalLeaderboard);
-        });
-      });
-    } catch (err) {
-      logger.error(`UPDATE leaderboard when withdrawing status changed error: ${err.message}`);
       throw err;
     }
   }

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -51,6 +51,8 @@ const initDB = async () => {
     await db.ResultSets.ensureIndex({ fieldName: 'txid', unique: true });
     await db.Withdraws.ensureIndex({ fieldName: 'txid', unique: true });
     await db.TransactionReceipts.ensureIndex({ fieldName: 'transactionHash' });
+    await db.GlobalLeaderboard.ensureIndex({ fieldName: 'userAddress', unique: true });
+    await db.EventLeaderboard.ensureIndex({ fieldName: 'eventAddress' });
 
     if (process.env.TEST_ENV !== 'true') {
       await applyMigrations();

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -13,6 +13,8 @@ const db = {
   Withdraws: undefined,
   Blocks: undefined,
   TransactionReceipts: undefined,
+  GlobalLeaderboard: undefined,
+  EventLeaderboard: undefined,
 };
 
 /**
@@ -28,6 +30,8 @@ const initDB = async () => {
   db.Withdraws = datastore({ filename: `${dbDir}/withdraws.db` });
   db.Blocks = datastore({ filename: `${dbDir}/blocks.db` });
   db.TransactionReceipts = datastore({ filename: `${dbDir}/transactionreceipts.db` });
+  db.GlobalLeaderboard = datastore({ filename: `${dbDir}/globalleaderboard.db` });
+  db.EventLeaderboard = datastore({ filename: `${dbDir}/eventleaderboard.db` });
 
   try {
     await Promise.all([
@@ -37,6 +41,8 @@ const initDB = async () => {
       db.Withdraws.loadDatabase(),
       db.Blocks.loadDatabase(),
       db.TransactionReceipts.loadDatabase(),
+      db.GlobalLeaderboard.loadDatabase(),
+      db.EventLeaderboard.loadDatabase(),
     ]);
 
     await db.Blocks.ensureIndex({ fieldName: 'blockNum', unique: true });

--- a/src/db/migrations/migration2.js
+++ b/src/db/migrations/migration2.js
@@ -9,84 +9,88 @@ const GlobalLeaderboard = require('../../models/global-leaderboard');
 
 const PROMISE_CONCURRENCY_LIMIT = 15;
 const limit = pLimit(PROMISE_CONCURRENCY_LIMIT);
-async function wrapper (dbMethod, callback) {
+
+async function wrapper(dbMethod, callback) {
   await dbMethod();
   callback();
 }
+
 async function migration2(next) {
   try {
     // migrate event leaderboard
     const events = await DBHelper.findEvent({ txStatus: TX_STATUS.SUCCESS });
     const promises = [];
 
-    events.forEach(async (event, key) => {
-      const eventAddress = event.address;
-      const resultSet = await DBHelper.findResultSet({ eventRound: 0, txStatus: TX_STATUS.SUCCESS, eventAddress: event.address });
-      const bets = await DBHelper.findBet({
-        eventAddress: event.address,
-        txStatus: TX_STATUS.SUCCESS,
-      });
-      const txs = resultSet.concat(bets);
+    events.forEach((event, key) => {
+      promises.push(limit(async () => {
+        const eventAddress = event.address;
+        const resultSet = await DBHelper.findResultSet({ eventRound: 0, txStatus: TX_STATUS.SUCCESS, eventAddress: event.address });
+        const bets = await DBHelper.findBet({
+          eventAddress: event.address,
+          txStatus: TX_STATUS.SUCCESS,
+        });
+        const txs = resultSet.concat(bets);
 
-      try {
-        let i = 0;
-        await async.whilst(
-          check => check(null, i < txs.length), // trigger iter
-          (next) => {
-            const tx = txs[i];
-            i++;
-            try {
-              const userAddress = tx.betterAddress || tx.centralizedOracleAddress;
-              const eventLeaderboardEntry = new EventLeaderboard({
-                eventAddress,
-                userAddress,
-                investments: tx.amount, // event leaderboard entry already has user's investments
-                winnings: '0',
-              });
-              wrapper(async () => {
-                  await DBHelper.insertEventLeaderboard(eventLeaderboardEntry)
-                  if(event.status === EVENT_STATUS.WITHDRAWING) {
-                    const globalLeaderboardEntry = new GlobalLeaderboard({
-                      userAddress,
-                      investments: tx.amount,
-                      winnings: '0',
-                    })
-                    await DBHelper.insertGlobalLeaderboard(globalLeaderboardEntry)
-                  }
-                },
-                ()=>next(null, i))
-            } catch (err) {
-              next(err, i); // err met, trigger the callback to end this loop
-            }
-          },
-        );
-      } catch (err) {
+        try {
+          let i = 0;
+          await async.whilst(
+            check => check(null, i < txs.length), // trigger iter
+            (next) => {
+              const tx = txs[i];
+              i++;
+              try {
+                const userAddress = tx.betterAddress || tx.centralizedOracleAddress;
+                const eventLeaderboardEntry = new EventLeaderboard({
+                  eventAddress,
+                  userAddress,
+                  investments: tx.amount,
+                  winnings: '0',
+                });
+                wrapper(
+                  async () => {
+                    await DBHelper.insertEventLeaderboard(eventLeaderboardEntry);
+                    if (event.status === EVENT_STATUS.WITHDRAWING) {
+                      const globalLeaderboardEntry = new GlobalLeaderboard({
+                        userAddress,
+                        investments: tx.amount,
+                        winnings: '0',
+                      });
+                      await DBHelper.insertGlobalLeaderboard(globalLeaderboardEntry);
+                    }
+                  },
+                  () => next(null, i),
+                );
+              } catch (err) {
+                next(err, i); // err met, trigger the callback to end this loop
+              }
+            },
+          );
+        } catch (err) {
         // will only be called if should end this loop
-        logger.error(err);
-        throw err;
-      }
-      if (event.status === EVENT_STATUS.WITHDRAWING) {
-        const addresses = new Set();
-        txs.forEach((tx, index) => {
-          if(tx.resultIndex !== event.currentResultIndex) return;
-          if(tx.betterAddress) addresses.add(tx.betterAddress);
-          if(tx.centralizedOracleAddress) addresses.add(tx.centralizedOracleAddress);
-        })
-        addresses.forEach((address, index) => {
-          promises.push(limit(async () => {
+          logger.error(err);
+          throw err;
+        }
+
+        if (event.status === EVENT_STATUS.WITHDRAWING) {
+          const addresses = new Set();
+          txs.forEach((tx, index) => {
+            if (tx.resultIndex !== event.currentResultIndex) return;
+            if (tx.betterAddress) addresses.add(tx.betterAddress);
+            if (tx.centralizedOracleAddress) addresses.add(tx.centralizedOracleAddress);
+          });
+          async.eachOfSeries(addresses, async (address, index) => {
             try {
               // calculate winning for this user in this event
-              let winnings = '0';
               const res = await MultipleResultsEventApi.calculateWinnings({
                 eventAddress,
-                address: address,
+                address,
               });
-              winnings = res.toString(10);
+              const winnings = res.toString(10);
               // update event leaderboard winnings
               const eventLeaderboardEntry = new EventLeaderboard({
                 eventAddress,
                 userAddress: address,
-                investments: '0', // event leaderboard entry already has user's investments
+                investments: '0',
                 winnings,
               });
               await DBHelper.insertEventLeaderboard(eventLeaderboardEntry);
@@ -94,14 +98,14 @@ async function migration2(next) {
                 userAddress: address,
                 investments: '0',
                 winnings,
-              })
-              await DBHelper.insertGlobalLeaderboard(globalLeaderboardEntry)
+              });
+              await DBHelper.insertGlobalLeaderboard(globalLeaderboardEntry);
             } catch (err) {
               logger.error('Migrate event leaderboard error:', err);
             }
-          }));
-        });
-      }
+          });
+        }
+      }));
     });
 
     await Promise.all(promises);

--- a/src/db/migrations/migration2.js
+++ b/src/db/migrations/migration2.js
@@ -1,0 +1,100 @@
+const { uniqBy } = require('lodash');
+const pLimit = require('p-limit');
+const async = require('async');
+const logger = require('../../utils/logger');
+const DBHelper = require('../db-helper');
+const { TX_STATUS, EVENT_STATUS } = require('../../constants');
+const MultipleResultsEventApi = require('../../api/multiple-results-event');
+const EventLeaderboard = require('../../models/event-leaderboard');
+
+const PROMISE_CONCURRENCY_LIMIT = 15;
+const limit = pLimit(PROMISE_CONCURRENCY_LIMIT);
+async function helper (dbMethod, callback) {
+  await dbMethod();
+  callback();
+}
+async function migration2(next) {
+  try {
+    // migrate event leaderboard
+    const events = await DBHelper.findEvent({ txStatus: TX_STATUS.SUCCESS });
+    const promises = [];
+
+    events.forEach(async (event, key) => {
+      const eventAddress = event.address;
+      const resultSet = await DBHelper.findResultSet({ eventRound: 0, txStatus: TX_STATUS.SUCCESS, eventAddress: event.address });
+      const bets = await DBHelper.findBet({
+        eventAddress: event.address,
+        txStatus: TX_STATUS.SUCCESS,
+      });
+      const txs = resultSet.concat(bets);
+
+      try {
+        let i = 0;
+        await async.whilst(
+          check => check(null, i < txs.length), // trigger iter
+          (next) => {
+            const tx = txs[i];
+            i++;
+
+            try {
+              const userAddress = tx.betterAddress || tx.centralizedOracleAddress;
+              const eventLeaderboardEntry = new EventLeaderboard({
+                eventAddress,
+                userAddress,
+                investments: tx.amount, // event leaderboard entry already has user's investments
+                winnings: '0',
+              });
+              helper(() => DBHelper.insertEventLeaderboard(eventLeaderboardEntry),()=>next(null, i))
+            } catch (err) {
+              next(err, i); // err met, trigger the callback to end this loop
+            }
+          },
+        );
+      } catch (err) {
+        // will only be called if should end this loop
+        logger.error(err);
+        throw err;
+      }
+      if (event.status === EVENT_STATUS.WITHDRAWING) {
+        const addresses = new Set();
+        txs.forEach((tx, index) => {
+          if(tx.resultIndex !== event.currentResultIndex) return;
+          if(tx.betterAddress) addresses.add(tx.betterAddress);
+          if(tx.centralizedOracleAddress) addresses.add(tx.centralizedOracleAddress);
+        })
+        addresses.forEach((address, index) => {
+          promises.push(limit(async () => {
+            try {
+              // calculate winning for this user in this event
+              let winnings = '0';
+              const res = await MultipleResultsEventApi.calculateWinnings({
+                eventAddress,
+                address: address,
+              });
+              winnings = res.toString(10);
+              // update event leaderboard winnings
+              const eventLeaderboardEntry = new EventLeaderboard({
+                eventAddress,
+                userAddress: address,
+                investments: '0', // event leaderboard entry already has user's investments
+                winnings,
+              });
+              await DBHelper.insertEventLeaderboard(eventLeaderboardEntry);
+            } catch (err) {
+              logger.error('Migrate event leaderboard error:', err);
+            }
+          }));
+        });
+      }
+    });
+
+    await Promise.all(promises);
+    logger.info('Migration 2 done');
+    next();
+  } catch (err) {
+    logger.error(`Migration 2 error: ${err.message}`);
+    throw err;
+  }
+}
+
+module.exports = migration2;

--- a/src/graphql/queries/index.js
+++ b/src/graphql/queries/index.js
@@ -10,6 +10,7 @@ const allStats = require('./all-stats');
 const mostBets = require('./most-bets');
 const biggestWinners = require('./biggest-winners');
 const withdrawableEvents = require('./withdrawable-events');
+const { eventLeaderboard, globalLeaderboard } = require('./leaderboard');
 
 module.exports = {
   events,
@@ -24,4 +25,6 @@ module.exports = {
   mostBets,
   biggestWinners,
   withdrawableEvents,
+  eventLeaderboard,
+  globalLeaderboard,
 };

--- a/src/graphql/queries/index.js
+++ b/src/graphql/queries/index.js
@@ -10,7 +10,7 @@ const allStats = require('./all-stats');
 const mostBets = require('./most-bets');
 const biggestWinners = require('./biggest-winners');
 const withdrawableEvents = require('./withdrawable-events');
-const { eventLeaderboard, globalLeaderboard } = require('./leaderboard');
+const { eventLeaderboardEntries, globalLeaderboardEntries } = require('./leaderboard');
 
 module.exports = {
   events,
@@ -25,6 +25,6 @@ module.exports = {
   mostBets,
   biggestWinners,
   withdrawableEvents,
-  eventLeaderboard,
-  globalLeaderboard,
+  eventLeaderboardEntries,
+  globalLeaderboardEntries,
 };

--- a/src/graphql/queries/leaderboard.js
+++ b/src/graphql/queries/leaderboard.js
@@ -1,4 +1,3 @@
-const { isArray, each } = require('lodash');
 const BigNumber = require('bignumber.js');
 const { lowercaseFilters, runPaginatedQuery } = require('./utils');
 
@@ -34,7 +33,9 @@ const eventLeaderboardEntries = async (
 
   if (orderBy && orderBy.length > 0) {
     const { field } = orderBy[0];
-    res.items.sort((a, b) => new BigNumber(b[field]).comparedTo(new BigNumber(a[field]))); // all descending
+    if (field !== 'eventAddress' && field !== 'userAddress') {
+      res.items.sort((a, b) => new BigNumber(b[field]).comparedTo(new BigNumber(a[field]))); // all descending
+    }
   }
 
   return res;
@@ -56,7 +57,9 @@ const globalLeaderboardEntries = async (
 
   if (orderBy && orderBy.length > 0) {
     const { field } = orderBy[0];
-    res.items.sort((a, b) => new BigNumber(b[field]).comparedTo(new BigNumber(a[field]))); // all descending
+    if (field !== 'eventAddress' && field !== 'userAddress') {
+      res.items.sort((a, b) => new BigNumber(b[field]).comparedTo(new BigNumber(a[field]))); // all descending
+    }
   }
 
   return res;

--- a/src/graphql/queries/leaderboard.js
+++ b/src/graphql/queries/leaderboard.js
@@ -1,0 +1,53 @@
+const { isArray, each } = require('lodash');
+const { lowercaseFilters, runPaginatedQuery } = require('./utils');
+
+const buildFilters = ({
+  userAddress,
+  eventAddress,
+} = {}) => {
+  if (!eventAddress && !userAddress) {
+    throw Error('eventAddress or userAddress missing in filters');
+  }
+  const filters = [];
+  const filter = {};
+  if (eventAddress) filter.eventAddress = eventAddress;
+  if (userAddress) filter.betterAddress = userAddress;
+
+  filters.push(filter);
+  return filters;
+};
+
+const eventLeaderboard = async (
+  root,
+  { filter, orderBy, limit, skip },
+  { db: { EventLeaderboard } },
+) => {
+  const query = filter ? { $or: buildFilters(lowercaseFilters(filter)) } : {};
+  return runPaginatedQuery({
+    db: EventLeaderboard,
+    filter: query,
+    orderBy,
+    limit,
+    skip,
+  });
+};
+
+const globalLeaderboard = async (
+  root,
+  { filter, orderBy, limit, skip },
+  { db: { GlobalLeaderboard } },
+) => {
+  const query = filter ? { $or: buildFilters(lowercaseFilters(filter)) } : {};
+  return runPaginatedQuery({
+    db: GlobalLeaderboard,
+    filter: query,
+    orderBy,
+    limit,
+    skip,
+  });
+};
+
+module.exports = {
+  eventLeaderboard,
+  globalLeaderboard,
+};

--- a/src/graphql/queries/leaderboard.js
+++ b/src/graphql/queries/leaderboard.js
@@ -6,7 +6,7 @@ const buildFilters = ({
   eventAddress,
 } = {}) => {
   if (!eventAddress && !userAddress) {
-    throw Error('eventAddress or userAddress missing in filters');
+    throw Error('eventAddress and/or userAddress missing in filters');
   }
   const filters = [];
   const filter = {};
@@ -17,7 +17,7 @@ const buildFilters = ({
   return filters;
 };
 
-const eventLeaderboard = async (
+const eventLeaderboardEntries = async (
   root,
   { filter, orderBy, limit, skip },
   { db: { EventLeaderboard } },
@@ -32,7 +32,7 @@ const eventLeaderboard = async (
   });
 };
 
-const globalLeaderboard = async (
+const globalLeaderboardEntries = async (
   root,
   { filter, orderBy, limit, skip },
   { db: { GlobalLeaderboard } },
@@ -48,6 +48,6 @@ const globalLeaderboard = async (
 };
 
 module.exports = {
-  eventLeaderboard,
-  globalLeaderboard,
+  eventLeaderboardEntries,
+  globalLeaderboardEntries,
 };

--- a/src/graphql/queries/leaderboard.js
+++ b/src/graphql/queries/leaderboard.js
@@ -1,4 +1,5 @@
 const { isArray, each } = require('lodash');
+const BigNumber = require('bignumber.js');
 const { lowercaseFilters, runPaginatedQuery } = require('./utils');
 
 const buildFilters = ({
@@ -23,13 +24,20 @@ const eventLeaderboardEntries = async (
   { db: { EventLeaderboard } },
 ) => {
   const query = filter ? { $or: buildFilters(lowercaseFilters(filter)) } : {};
-  return runPaginatedQuery({
+  const res = await runPaginatedQuery({
     db: EventLeaderboard,
     filter: query,
     orderBy,
     limit,
     skip,
   });
+
+  if (orderBy && orderBy.length > 0) {
+    const { field } = orderBy[0];
+    res.items.sort((a, b) => new BigNumber(b[field]).comparedTo(new BigNumber(a[field]))); // all descending
+  }
+
+  return res;
 };
 
 const globalLeaderboardEntries = async (
@@ -38,13 +46,20 @@ const globalLeaderboardEntries = async (
   { db: { GlobalLeaderboard } },
 ) => {
   const query = filter ? { $or: buildFilters(lowercaseFilters(filter)) } : {};
-  return runPaginatedQuery({
+  const res = await runPaginatedQuery({
     db: GlobalLeaderboard,
     filter: query,
     orderBy,
     limit,
     skip,
   });
+
+  if (orderBy && orderBy.length > 0) {
+    const { field } = orderBy[0];
+    res.items.sort((a, b) => new BigNumber(b[field]).comparedTo(new BigNumber(a[field]))); // all descending
+  }
+
+  return res;
 };
 
 module.exports = {

--- a/src/graphql/queries/leaderboard.js
+++ b/src/graphql/queries/leaderboard.js
@@ -11,7 +11,7 @@ const buildFilters = ({
   const filters = [];
   const filter = {};
   if (eventAddress) filter.eventAddress = eventAddress;
-  if (userAddress) filter.betterAddress = userAddress;
+  if (userAddress) filter.userAddress = userAddress;
 
   filters.push(filter);
   return filters;

--- a/src/graphql/queries/utils.js
+++ b/src/graphql/queries/utils.js
@@ -27,6 +27,7 @@ const lowercaseFilters = (filters) => {
     'centralizedOracleAddress',
     'winnerAddress',
     'transactorAddress',
+    'userAddress',
   ];
 
   // Loop through each filter

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -239,18 +239,18 @@ type PaginatedBiggestWinner {
   items: [BiggestWinner]!
 }
 
-type Leaderboard {
+type LeaderboardEntry {
   eventAddress: String
   userAddress: String!
   investments: String!
   winnings: String!
-  returnRatio: String!
+  returnRatio: Float!
 }
 
-type PaginatedLeaderboard {
+type PaginatedLeaderboardEntry {
   totalCount: Int!
   pageInfo: PageInfo
-  items: [Leaderboard]!
+  items: [LeaderboardEntry]!
 }
 
 input Order {
@@ -258,7 +258,7 @@ input Order {
   direction: OrderDirection!
 }
 
-input LeaderboardFilter {
+input LeaderboardEntryFilter {
   userAddress: String
   eventAddress: String
 }
@@ -418,19 +418,19 @@ type Query {
     skip: Int
   ): PaginatedBiggestWinner!
 
-  eventLeaderboard(
-    filter: LeaderboardFilter
+  eventLeaderboardEntries(
+    filter: LeaderboardEntryFilter
     orderBy: [Order!]
     limit: Int
     skip: Int
-  ): PaginatedLeaderboard!
+  ): PaginatedLeaderboardEntry!
 
-  globalLeaderboard(
-    filter: LeaderboardFilter
+  globalLeaderboardEntries(
+    filter: LeaderboardEntryFilter
     orderBy: [Order!]
     limit: Int
     skip: Int
-  ): PaginatedLeaderboard!
+  ): PaginatedLeaderboardEntry!
 }
 
 type Mutation {

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -239,9 +239,28 @@ type PaginatedBiggestWinner {
   items: [BiggestWinner]!
 }
 
+type Leaderboard {
+  eventAddress: String
+  userAddress: String!
+  investments: String!
+  winnings: String!
+  returnRatio: String!
+}
+
+type PaginatedLeaderboard {
+  totalCount: Int!
+  pageInfo: PageInfo
+  items: [Leaderboard]!
+}
+
 input Order {
   field: String!
   direction: OrderDirection!
+}
+
+input LeaderboardFilter {
+  userAddress: String
+  eventAddress: String
 }
 
 input EventFilter {
@@ -398,6 +417,20 @@ type Query {
     limit: Int
     skip: Int
   ): PaginatedBiggestWinner!
+
+  eventLeaderboard(
+    filter: LeaderboardFilter
+    orderBy: [Order!]
+    limit: Int
+    skip: Int
+  ): PaginatedLeaderboard!
+
+  globalLeaderboard(
+    filter: LeaderboardFilter
+    orderBy: [Order!]
+    limit: Int
+    skip: Int
+  ): PaginatedLeaderboard!
 }
 
 type Mutation {

--- a/src/models/event-leaderboard.js
+++ b/src/models/event-leaderboard.js
@@ -1,0 +1,26 @@
+/* eslint no-underscore-dangle: 0 */
+const { isFinite, isString } = require('lodash');
+const { toLowerCase } = require('../utils');
+
+module.exports = class GlobalLeaderboard {
+  constructor(params) {
+    this.validate(params);
+    this.format(params);
+  }
+
+  validate(params) {
+    if (!isString(params.userAddress)) throw Error('userAddress must be a String');
+    if (!isString(params.eventAddress)) throw Error('eventAddress must be a String');
+    if (!isString(params.investments)) throw Error('investments must be a Number');
+    if (!isFinite(params.winnings)) throw Error('winnings must be a Number');
+    if (!isString(params.returnRatio)) throw Error('returnRatio must be a Number');
+  }
+
+  format(params) {
+    this.eventAddress = toLowerCase(params.eventAddress);
+    this.userAddress = toLowerCase(params.userAddress);
+    this.investments = params.investments;
+    this.winnings = params.winnings;
+    this.returnRatio = params.returnRatio;
+  }
+};

--- a/src/models/event-leaderboard.js
+++ b/src/models/event-leaderboard.js
@@ -1,8 +1,8 @@
-/* eslint no-underscore-dangle: 0 */
-const { isFinite, isString } = require('lodash');
+const { isString } = require('lodash');
+const BigNumber = require('bignumber.js');
 const { toLowerCase } = require('../utils');
 
-module.exports = class GlobalLeaderboard {
+module.exports = class EventLeaderboard {
   constructor(params) {
     this.validate(params);
     this.format(params);
@@ -11,8 +11,8 @@ module.exports = class GlobalLeaderboard {
   validate(params) {
     if (!isString(params.userAddress)) throw Error('userAddress must be a String');
     if (!isString(params.eventAddress)) throw Error('eventAddress must be a String');
-    if (!isString(params.investments)) throw Error('investments must be a Number');
-    if (!isFinite(params.winnings)) throw Error('winnings must be a Number');
+    if (!isString(params.investments)) throw Error('investments must be a String');
+    if (!isString(params.winnings)) throw Error('winnings must be a String');
   }
 
   format(params) {
@@ -20,6 +20,7 @@ module.exports = class GlobalLeaderboard {
     this.userAddress = toLowerCase(params.userAddress);
     this.investments = params.investments;
     this.winnings = params.winnings;
-    this.returnRatio = this.winnings / this.investments;
+    const ratio = new BigNumber(this.winnings).dividedBy(new BigNumber(this.investments));
+    this.returnRatio = ratio.toString();
   }
 };

--- a/src/models/event-leaderboard.js
+++ b/src/models/event-leaderboard.js
@@ -21,6 +21,6 @@ module.exports = class EventLeaderboard {
     this.investments = params.investments;
     this.winnings = params.winnings;
     const ratio = new BigNumber(this.winnings).dividedBy(new BigNumber(this.investments));
-    this.returnRatio = ratio.toString();
+    this.returnRatio = ratio.toNumber();
   }
 };

--- a/src/models/event-leaderboard.js
+++ b/src/models/event-leaderboard.js
@@ -13,7 +13,6 @@ module.exports = class GlobalLeaderboard {
     if (!isString(params.eventAddress)) throw Error('eventAddress must be a String');
     if (!isString(params.investments)) throw Error('investments must be a Number');
     if (!isFinite(params.winnings)) throw Error('winnings must be a Number');
-    if (!isString(params.returnRatio)) throw Error('returnRatio must be a Number');
   }
 
   format(params) {
@@ -21,6 +20,6 @@ module.exports = class GlobalLeaderboard {
     this.userAddress = toLowerCase(params.userAddress);
     this.investments = params.investments;
     this.winnings = params.winnings;
-    this.returnRatio = params.returnRatio;
+    this.returnRatio = this.winnings / this.investments;
   }
 };

--- a/src/models/global-leaderboard.js
+++ b/src/models/global-leaderboard.js
@@ -1,0 +1,24 @@
+/* eslint no-underscore-dangle: 0 */
+const { isFinite, isString } = require('lodash');
+const { toLowerCase } = require('../utils');
+
+module.exports = class GlobalLeaderboard {
+  constructor(params) {
+    this.validate(params);
+    this.format(params);
+  }
+
+  validate(params) {
+    if (!isString(params.userAddress)) throw Error('userAddress must be a String');
+    if (!isString(params.investments)) throw Error('investments must be a Number');
+    if (!isFinite(params.winnings)) throw Error('winnings must be a Number');
+    if (!isString(params.returnRatio)) throw Error('returnRatio must be a Number');
+  }
+
+  format(params) {
+    this.userAddress = toLowerCase(params.userAddress);
+    this.investments = params.investments;
+    this.winnings = params.winnings;
+    this.returnRatio = params.returnRatio;
+  }
+};

--- a/src/models/global-leaderboard.js
+++ b/src/models/global-leaderboard.js
@@ -12,13 +12,12 @@ module.exports = class GlobalLeaderboard {
     if (!isString(params.userAddress)) throw Error('userAddress must be a String');
     if (!isString(params.investments)) throw Error('investments must be a Number');
     if (!isFinite(params.winnings)) throw Error('winnings must be a Number');
-    if (!isString(params.returnRatio)) throw Error('returnRatio must be a Number');
   }
 
   format(params) {
     this.userAddress = toLowerCase(params.userAddress);
     this.investments = params.investments;
     this.winnings = params.winnings;
-    this.returnRatio = params.returnRatio;
+    this.returnRatio = this.winnings / this.investments;
   }
 };

--- a/src/models/global-leaderboard.js
+++ b/src/models/global-leaderboard.js
@@ -19,6 +19,6 @@ module.exports = class GlobalLeaderboard {
     this.investments = params.investments;
     this.winnings = params.winnings;
     const ratio = new BigNumber(this.winnings).dividedBy(new BigNumber(this.investments));
-    this.returnRatio = ratio.toString();
+    this.returnRatio = ratio.toNumber();
   }
 };

--- a/src/models/global-leaderboard.js
+++ b/src/models/global-leaderboard.js
@@ -1,5 +1,5 @@
-/* eslint no-underscore-dangle: 0 */
-const { isFinite, isString } = require('lodash');
+const { isString } = require('lodash');
+const BigNumber = require('bignumber.js');
 const { toLowerCase } = require('../utils');
 
 module.exports = class GlobalLeaderboard {
@@ -10,14 +10,15 @@ module.exports = class GlobalLeaderboard {
 
   validate(params) {
     if (!isString(params.userAddress)) throw Error('userAddress must be a String');
-    if (!isString(params.investments)) throw Error('investments must be a Number');
-    if (!isFinite(params.winnings)) throw Error('winnings must be a Number');
+    if (!isString(params.investments)) throw Error('investments must be a String');
+    if (!isString(params.winnings)) throw Error('winnings must be a String');
   }
 
   format(params) {
     this.userAddress = toLowerCase(params.userAddress);
     this.investments = params.investments;
     this.winnings = params.winnings;
-    this.returnRatio = this.winnings / this.investments;
+    const ratio = new BigNumber(this.winnings).dividedBy(new BigNumber(this.investments));
+    this.returnRatio = ratio.toString();
   }
 };

--- a/src/sync/bet-placed.js
+++ b/src/sync/bet-placed.js
@@ -82,6 +82,7 @@ const pendingBetPlaced = async ({ syncPromises, limit }) => {
             if (foundLog) {
               const bet = parseBet({ log: foundLog });
               await DBHelper.insertBet(bet);
+
               // Update event leaderboard investments
               const leaderboardEntry = new EventLeaderboard({
                 eventAddress: bet.eventAddress,

--- a/src/sync/bet-placed.js
+++ b/src/sync/bet-placed.js
@@ -7,6 +7,7 @@ const { getTransactionReceipt } = require('../utils/web3-utils');
 const DBHelper = require('../db/db-helper');
 const EventSig = require('../config/event-sig');
 const parseBet = require('./parsers/bet');
+const MultipleResultsEventApi = require('../api/multiple-results-event');
 
 const syncBetPlaced = async ({ startBlock, endBlock, syncPromises, limit }) => {
   try {

--- a/src/sync/bet-placed.js
+++ b/src/sync/bet-placed.js
@@ -7,7 +7,6 @@ const { getTransactionReceipt } = require('../utils/web3-utils');
 const DBHelper = require('../db/db-helper');
 const EventSig = require('../config/event-sig');
 const parseBet = require('./parsers/bet');
-const MultipleResultsEventApi = require('../api/multiple-results-event');
 const EventLeaderboard = require('../models/event-leaderboard');
 
 const syncBetPlaced = async ({ startBlock, endBlock, syncPromises, limit }) => {

--- a/src/sync/bet-placed.js
+++ b/src/sync/bet-placed.js
@@ -37,7 +37,7 @@ const syncBetPlaced = async ({ startBlock, endBlock, syncPromises, limit }) => {
             eventAddress: bet.eventAddress,
             userAddress: bet.betterAddress,
             investments: bet.amount,
-            winnings: 0,
+            winnings: '0',
           });
           await DBHelper.insertEventLeaderboard(leaderboardEntry);
         } catch (insertErr) {
@@ -87,7 +87,7 @@ const pendingBetPlaced = async ({ syncPromises, limit }) => {
                 eventAddress: bet.eventAddress,
                 userAddress: bet.betterAddress,
                 investments: bet.amount,
-                winnings: 0,
+                winnings: '0',
               });
               await DBHelper.insertEventLeaderboard(leaderboardEntry);
             }

--- a/src/sync/event-status-withdrawing-changed.js
+++ b/src/sync/event-status-withdrawing-changed.js
@@ -1,0 +1,112 @@
+const { each, isNull, find } = require('lodash');
+const web3 = require('../web3');
+const { TX_STATUS } = require('../constants');
+const EventSig = require('../config/event-sig');
+const { toLowerCase } = require('../utils');
+const { getTransactionReceipt } = require('../utils/web3-utils');
+const logger = require('../utils/logger');
+const DBHelper = require('../db/db-helper');
+const parseEvent = require('./parsers/multiple-results-event');
+const MultipleResultsEventApi = require('../api/multiple-results-event');
+const EventLeaderboard = require('../models/event-leaderboard');
+const GlobalLeaderboard = require('../models/global-leaderboard');
+
+const getInvestments = async (txs) => {
+  const accumulated = txs.reduce((acc, cur) => {
+    const amount = web3.utils.toBN(cur.amount);
+    if (!cur.betterAddress) cur.betterAddress = cur.centralizedOracleAddress;
+    if (Object.keys(acc).includes(cur.betterAddress)) {
+      acc[cur.betterAddress] = web3.utils.toBN(acc[cur.betterAddress]).add(amount).toString(10);
+    } else {
+      acc[cur.betterAddress] = amount.toString(10);
+    }
+    return acc;
+  }, {});
+
+  return accumulated;
+};
+
+const updateLeaderboardWithdrawing = async (syncPromises, events, limit) => {
+  each(events, async (event) => {
+    syncPromises.push(limit(async () => {
+      try {
+        // get all the participants
+        const bets = await DBHelper.findBet({
+          eventAddress: event.address,
+          txStatus: TX_STATUS.SUCCESS,
+        });
+        const resultSets = await DBHelper.findResultSet({
+          eventAddress: event.address,
+          txStatus: TX_STATUS.SUCCESS,
+          eventRound: 0,
+        });
+        const txs = resultSets.concat(bets);
+        const investments = await getInvestments(txs);
+        const filtered = [];
+        each(txs, (tx) => {
+          if (!find(filtered, {
+            eventAddress: tx.eventAddress,
+            betterAddress: tx.betterAddress,
+          })) {
+            filtered.push(tx);
+          }
+        });
+        // calculate winnings for all participants
+        const promises = [];
+        each(filtered, (tx) => {
+          promises.push(new Promise(async (resolve, reject) => {
+            try {
+              const { eventAddress, betterAddress, resultIndex, centralizedOracleAddress } = tx;
+              const userAddress = betterAddress || centralizedOracleAddress;
+              // calculate winning for this user in this event
+              let winning = '0';
+              if (resultIndex === event.currentResultIndex) {
+                const res = await MultipleResultsEventApi.calculateWinnings({
+                  eventAddress,
+                  address: userAddress,
+                });
+                winning = res.toString(10);
+              }
+              // update event leaderboard winnings
+              const eventLeaderboardEntry = new EventLeaderboard({
+                eventAddress,
+                userAddress,
+                investments: '0', // event leaderboard entry already has user's investments
+                winnings: winning,
+              });
+              await DBHelper.insertEventLeaderboard(eventLeaderboardEntry);
+              // update global leaderboard investments, winnings
+              const globalLeaderboard = new GlobalLeaderboard({
+                userAddress,
+                investments: investments[userAddress],
+                winnings: winning,
+              });
+              await DBHelper.insertGlobalLeaderboard(globalLeaderboard);
+              resolve();
+            } catch (err) {
+              reject(err);
+            }
+          }));
+        });
+        await Promise.all(promises);
+      } catch (err) {
+        logger.error(`UPDATE leaderboard when withdrawing status changed error: ${err.message}`);
+        throw err;
+      }
+    }));
+  });
+};
+
+const updateEventStatusWithdrawingAndLeaderboard = async (
+  { blockTime, syncPromises, limit },
+) => {
+  try {
+    const updatedEvents = await DBHelper.updateEventStatusWithdrawing(blockTime);
+    await updateLeaderboardWithdrawing(syncPromises, updatedEvents[1], limit);
+  } catch (err) {
+    logger.error('Error event status withdrawing changed');
+    throw err;
+  }
+};
+
+module.exports = updateEventStatusWithdrawingAndLeaderboard;

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -18,7 +18,7 @@ const {
   pendingWinningsWithdrawn,
 } = require('./winnings-withdrawn');
 const syncBlocks = require('./blocks');
-const updateEventStatusWithdrawingAndLeaderboard = require('./event-status-withdrawing-changed');
+const updateLeaderboard = require('./update-leaderboard');
 const DBHelper = require('../db/db-helper');
 const logger = require('../utils/logger');
 const { publishSyncInfo } = require('../graphql/subscriptions');
@@ -206,9 +206,9 @@ const startSync = async () => {
     await DBHelper.updateEventStatusOracleResultSetting(blockTime);
     await DBHelper.updateEventStatusOpenResultSetting(blockTime);
     await DBHelper.updateEventStatusArbitration(blockTime);
-    // await DBHelper.updateEventStatusWithdrawing(blockTime);
+    const newWithdrawEvents = await DBHelper.updateEventStatusWithdrawing(blockTime);
     syncPromises = [];
-    await updateEventStatusWithdrawingAndLeaderboard({ blockTime, syncPromises, limit });
+    await updateLeaderboard({ newWithdrawEvents, syncPromises, limit });
     await Promise.all(syncPromises);
 
     // Send syncInfo subscription message

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -18,6 +18,7 @@ const {
   pendingWinningsWithdrawn,
 } = require('./winnings-withdrawn');
 const syncBlocks = require('./blocks');
+const updateEventStatusWithdrawingAndLeaderboard = require('./event-status-withdrawing-changed');
 const DBHelper = require('../db/db-helper');
 const logger = require('../utils/logger');
 const { publishSyncInfo } = require('../graphql/subscriptions');
@@ -205,7 +206,10 @@ const startSync = async () => {
     await DBHelper.updateEventStatusOracleResultSetting(blockTime);
     await DBHelper.updateEventStatusOpenResultSetting(blockTime);
     await DBHelper.updateEventStatusArbitration(blockTime);
-    await DBHelper.updateEventStatusWithdrawing(blockTime);
+    // await DBHelper.updateEventStatusWithdrawing(blockTime);
+    syncPromises = [];
+    await updateEventStatusWithdrawingAndLeaderboard({ blockTime, syncPromises, limit });
+    await Promise.all(syncPromises);
 
     // Send syncInfo subscription message
     await publishSyncInfo(endBlock, blockTime);

--- a/src/sync/result-set.js
+++ b/src/sync/result-set.js
@@ -8,6 +8,7 @@ const { getTransactionReceipt } = require('../utils/web3-utils');
 const DBHelper = require('../db/db-helper');
 const EventSig = require('../config/event-sig');
 const parseResultSet = require('./parsers/result-set');
+const EventLeaderboard = require('../models/event-leaderboard');
 
 const syncResultSet = async ({ startBlock, endBlock, syncPromises, limit }) => {
   try {
@@ -34,6 +35,15 @@ const syncResultSet = async ({ startBlock, endBlock, syncPromises, limit }) => {
 
           // Update event
           await updateEvent(resultSet);
+
+          // Update event leaderboard investments
+          const leaderboardEntry = new EventLeaderboard({
+            eventAddress: resultSet.eventAddress,
+            userAddress: resultSet.centralizedOracleAddress,
+            investments: resultSet.amount,
+            winnings: 0,
+          });
+          await DBHelper.insertEventLeaderboard(leaderboardEntry);
         } catch (insertErr) {
           logger.error('Error syncResultSet parse');
           throw insertErr;
@@ -79,6 +89,15 @@ const pendingResultSet = async ({ syncPromises, limit }) => {
 
               // Update event
               await updateEvent(resultSet);
+
+              // Update event leaderboard investments
+              const leaderboardEntry = new EventLeaderboard({
+                eventAddress: resultSet.eventAddress,
+                userAddress: resultSet.centralizedOracleAddress,
+                investments: resultSet.amount,
+                winnings: 0,
+              });
+              await DBHelper.insertEventLeaderboard(leaderboardEntry);
             }
           } else {
             // Update result set with failed status

--- a/src/sync/result-set.js
+++ b/src/sync/result-set.js
@@ -41,7 +41,7 @@ const syncResultSet = async ({ startBlock, endBlock, syncPromises, limit }) => {
             eventAddress: resultSet.eventAddress,
             userAddress: resultSet.centralizedOracleAddress,
             investments: resultSet.amount,
-            winnings: 0,
+            winnings: '0',
           });
           await DBHelper.insertEventLeaderboard(leaderboardEntry);
         } catch (insertErr) {
@@ -95,7 +95,7 @@ const pendingResultSet = async ({ syncPromises, limit }) => {
                 eventAddress: resultSet.eventAddress,
                 userAddress: resultSet.centralizedOracleAddress,
                 investments: resultSet.amount,
-                winnings: 0,
+                winnings: '0',
               });
               await DBHelper.insertEventLeaderboard(leaderboardEntry);
             }

--- a/src/sync/update-leaderboard.js
+++ b/src/sync/update-leaderboard.js
@@ -1,13 +1,9 @@
-const { each, isNull, find } = require('lodash');
+const { each, find } = require('lodash');
 const async = require('async');
 const web3 = require('../web3');
 const { TX_STATUS } = require('../constants');
-const EventSig = require('../config/event-sig');
-const { toLowerCase } = require('../utils');
-const { getTransactionReceipt } = require('../utils/web3-utils');
 const logger = require('../utils/logger');
 const DBHelper = require('../db/db-helper');
-const parseEvent = require('./parsers/multiple-results-event');
 const MultipleResultsEventApi = require('../api/multiple-results-event');
 const EventLeaderboard = require('../models/event-leaderboard');
 const GlobalLeaderboard = require('../models/global-leaderboard');
@@ -88,7 +84,7 @@ const updateLeaderboardWithdrawing = async (syncPromises, events, limit) => {
             filtered.push(tx);
           }
         });
-        async.eachOfSeries(filtered, (value, key, callback) => {
+        await async.eachOfSeries(filtered, (value, key, callback) => {
           try {
             const { eventAddress, betterAddress, centralizedOracleAddress } = value;
             const userAddress = betterAddress || centralizedOracleAddress;

--- a/src/sync/update-leaderboard.js
+++ b/src/sync/update-leaderboard.js
@@ -98,10 +98,10 @@ const updateLeaderboardWithdrawing = async (syncPromises, events, limit) => {
 };
 
 const updateLeaderboard = async (
-  { events, syncPromises, limit },
+  { newWithdrawEvents, syncPromises, limit },
 ) => {
   try {
-    await updateLeaderboardWithdrawing(syncPromises, events[1], limit);
+    await updateLeaderboardWithdrawing(syncPromises, newWithdrawEvents[1], limit);
   } catch (err) {
     logger.error('Error event status withdrawing changed');
     throw err;

--- a/src/sync/update-leaderboard.js
+++ b/src/sync/update-leaderboard.js
@@ -88,7 +88,7 @@ const updateLeaderboardWithdrawing = async (syncPromises, events, limit) => {
             filtered.push(tx);
           }
         });
-        async.forEachOf(filtered, (value, key, callback) => {
+        async.eachOfSeries(filtered, (value, key, callback) => {
           try {
             const { eventAddress, betterAddress, centralizedOracleAddress } = value;
             const userAddress = betterAddress || centralizedOracleAddress;

--- a/src/sync/vote-placed.js
+++ b/src/sync/vote-placed.js
@@ -7,6 +7,7 @@ const { getTransactionReceipt } = require('../utils/web3-utils');
 const DBHelper = require('../db/db-helper');
 const EventSig = require('../config/event-sig');
 const parseBet = require('./parsers/bet');
+const EventLeaderboard = require('../models/event-leaderboard');
 
 const syncVotePlaced = async ({ startBlock, endBlock, syncPromises, limit }) => {
   try {
@@ -30,6 +31,15 @@ const syncVotePlaced = async ({ startBlock, endBlock, syncPromises, limit }) => 
           // Fetch and insert tx receipt
           const txReceipt = await getTransactionReceipt(bet.txid);
           await DBHelper.insertTransactionReceipt(txReceipt);
+
+          // Update event leaderboard investments
+          const leaderboardEntry = new EventLeaderboard({
+            eventAddress: bet.eventAddress,
+            userAddress: bet.betterAddress,
+            investments: bet.amount,
+            winnings: 0,
+          });
+          await DBHelper.insertEventLeaderboard(leaderboardEntry);
         } catch (insertErr) {
           logger.error('Error syncVotePlaced parse');
           throw insertErr;
@@ -72,6 +82,15 @@ const pendingVotePlaced = async ({ syncPromises, limit }) => {
             if (foundLog) {
               const bet = parseBet({ log: foundLog });
               await DBHelper.insertBet(bet);
+
+              // Update event leaderboard investments
+              const leaderboardEntry = new EventLeaderboard({
+                eventAddress: bet.eventAddress,
+                userAddress: bet.betterAddress,
+                investments: bet.amount,
+                winnings: 0,
+              });
+              await DBHelper.insertEventLeaderboard(leaderboardEntry);
             }
           } else {
             // Update bet with failed status

--- a/src/sync/vote-placed.js
+++ b/src/sync/vote-placed.js
@@ -37,7 +37,7 @@ const syncVotePlaced = async ({ startBlock, endBlock, syncPromises, limit }) => 
             eventAddress: bet.eventAddress,
             userAddress: bet.betterAddress,
             investments: bet.amount,
-            winnings: 0,
+            winnings: '0',
           });
           await DBHelper.insertEventLeaderboard(leaderboardEntry);
         } catch (insertErr) {
@@ -88,7 +88,7 @@ const pendingVotePlaced = async ({ syncPromises, limit }) => {
                 eventAddress: bet.eventAddress,
                 userAddress: bet.betterAddress,
                 investments: bet.amount,
-                winnings: 0,
+                winnings: '0',
               });
               await DBHelper.insertEventLeaderboard(leaderboardEntry);
             }

--- a/test/db/index.js
+++ b/test/db/index.js
@@ -1800,7 +1800,7 @@ describe('db', () => {
     let eventLeaderboardEntryCount;
 
     describe('findEventLeaderboard', () => {
-      it('find empty withdraw db', async () => {
+      it('find empty leaderboard db', async () => {
         eventLeaderboardEntryCount = await db.EventLeaderboard.count({});
         eventLeaderboardEntryCount.should.equal(0);
         eventLeaderboardEntry = await DBHelper.findEventLeaderboard({});
@@ -1943,7 +1943,7 @@ describe('db', () => {
         expect(eventLeaderboardEntry).excluding(['_id']).to.deep.equal(newEntry);
       });
 
-      it('should not update withdraw when eventAddress is not existed', async () => {
+      it('should not update leaderboard when eventAddress is not existed', async () => {
         const newEntry = {
           eventAddress: '0x12345',
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
@@ -1963,7 +1963,7 @@ describe('db', () => {
         should.not.exist(eventLeaderboardEntry);
       });
 
-      it('should not update withdraw when userAddress is not existed', async () => {
+      it('should not update leaderboard when userAddress is not existed', async () => {
         const newEntry = {
           eventAddress: '0x12345ea6e4e1f5375f7596b73b3b597e6507201a',
           userAddress: '0x12345',
@@ -2131,7 +2131,7 @@ describe('db', () => {
         expect(globalLeaderboardEntry).excluding(['_id']).to.deep.equal(newEntry);
       });
 
-      it('should not update withdraw when userAddress is not existed', async () => {
+      it('should not update leaderboard when userAddress is not existed', async () => {
         const newEntry = {
           userAddress: '0x12345',
           investments: '0',

--- a/test/db/index.js
+++ b/test/db/index.js
@@ -1779,21 +1779,21 @@ describe('db', () => {
         userAddress: '0x939592864c0bd3355b2d54e4fa2203e8343b6d6a',
         investments: '1000000000',
         winnings: '1000000000',
-        returnRatio: '1',
+        returnRatio: 1,
       },
       {
         eventAddress: '0x09645ea6e4e1f5375f7596b73b3b597e6507201a',
         userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
         investments: '5000000',
         winnings: '5000000',
-        returnRatio: '1',
+        returnRatio: 1,
       },
       {
         eventAddress: '0x12345ea6e4e1f5375f7596b73b3b597e6507201a',
         userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
         investments: '2000000',
         winnings: '0',
-        returnRatio: '0',
+        returnRatio: 0,
       },
     ];
     let eventLeaderboardEntry;
@@ -1867,14 +1867,14 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
           investments: '2000000',
           winnings: '0',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         const expectedEntry = {
           eventAddress: '0x12345ea6e4e1f5375f7596b73b3b597e6507201a',
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
           investments: '4000000',
           winnings: '0',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         eventLeaderboardEntryCount = await db.EventLeaderboard.count({});
         eventLeaderboardEntryCount.should.equal(3);
@@ -1895,14 +1895,14 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         const expectedEntry = {
           eventAddress: '0x12345ea6e4e1f5375f7596b73b3b597e6507201a',
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
           investments: '4000000',
           winnings: '2000000',
-          returnRatio: '0.5',
+          returnRatio: 0.5,
         };
         eventLeaderboardEntryCount = await db.EventLeaderboard.count({});
         eventLeaderboardEntryCount.should.equal(3);
@@ -1925,7 +1925,7 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         eventLeaderboardEntry = await DBHelper.findOneEventLeaderboard({
           userAddress: mockEventLeaderboard[2].userAddress,
@@ -1949,7 +1949,7 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         eventLeaderboardEntryCount = await db.EventLeaderboard.count({});
         eventLeaderboardEntryCount.should.equal(3);
@@ -1969,7 +1969,7 @@ describe('db', () => {
           userAddress: '0x12345',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         eventLeaderboardEntryCount = await db.EventLeaderboard.count({});
         eventLeaderboardEntryCount.should.equal(3);
@@ -1992,19 +1992,19 @@ describe('db', () => {
         userAddress: '0x939592864c0bd3355b2d54e4fa2203e8343b6d6a',
         investments: '1000000000',
         winnings: '1000000000',
-        returnRatio: '1',
+        returnRatio: 1,
       },
       {
         userAddress: '0x123456764c0bd3355b2d54e4fa2203e8343b6d6a',
         investments: '5000000',
         winnings: '5000000',
-        returnRatio: '1',
+        returnRatio: 1,
       },
       {
         userAddress: '0x123456764c0bd3355b2d54e4fa2203e834111111',
         investments: '2000000',
         winnings: '0',
-        returnRatio: '0',
+        returnRatio: 0,
       },
     ];
     let globalLeaderboardEntry;
@@ -2071,13 +2071,13 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e834111111',
           investments: '2000000',
           winnings: '0',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         const expectedEntry = {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e834111111',
           investments: '4000000',
           winnings: '0',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         globalLeaderboardEntryCount = await db.GlobalLeaderboard.count({});
         globalLeaderboardEntryCount.should.equal(3);
@@ -2094,13 +2094,13 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e834111111',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         const expectedEntry = {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e834111111',
           investments: '4000000',
           winnings: '2000000',
-          returnRatio: '0.5',
+          returnRatio: 0.5,
         };
         globalLeaderboardEntryCount = await db.GlobalLeaderboard.count({});
         globalLeaderboardEntryCount.should.equal(3);
@@ -2119,7 +2119,7 @@ describe('db', () => {
           userAddress: '0x123456764c0bd3355b2d54e4fa2203e834111111',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         globalLeaderboardEntry = await DBHelper.findOneGlobalLeaderboard({ userAddress: mockGlobalLeaderboard[2].userAddress });
         expect(globalLeaderboardEntry).excluding(['_id']).to.deep.not.equal(newEntry);
@@ -2136,7 +2136,7 @@ describe('db', () => {
           userAddress: '0x12345',
           investments: '0',
           winnings: '2000000',
-          returnRatio: '0',
+          returnRatio: 0,
         };
         globalLeaderboardEntryCount = await db.GlobalLeaderboard.count({});
         globalLeaderboardEntryCount.should.equal(3);

--- a/test/graphql/queries.tests.js
+++ b/test/graphql/queries.tests.js
@@ -453,7 +453,7 @@ describe('graphql/queries', () => {
     it('should return the query', async () => {
       const valid = `
         query {
-          eventLeaderboard(filter: {
+          eventLeaderboardEntries(filter: {
             userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a",
             eventAddress:"0x09645ea6e4e1f5375f7596b73b3b597e6507201a"
           }) {
@@ -467,7 +467,7 @@ describe('graphql/queries', () => {
     it('should accept the eventAddress filter', async () => {
       const valid = `
         query {
-          eventLeaderboard(filter: { eventAddress: "0x09645ea6e4e1f5375f7596b73b3b597e6507201a" }) {
+          eventLeaderboardEntries(filter: { eventAddress: "0x09645ea6e4e1f5375f7596b73b3b597e6507201a" }) {
             ${PAGINATED_LEADERBOARD}
           }
         }
@@ -478,7 +478,7 @@ describe('graphql/queries', () => {
     it('should accept the userAddress filter', async () => {
       const valid = `
         query {
-          eventLeaderboard(filter: { userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a" }) {
+          eventLeaderboardEntries(filter: { userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a" }) {
             ${PAGINATED_LEADERBOARD}
           }
         }
@@ -491,7 +491,7 @@ describe('graphql/queries', () => {
     it('should return the query', async () => {
       const valid = `
         query {
-          globalLeaderboard(filter: {
+          globalLeaderboardEntries(filter: {
             userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a",
             eventAddress:"0x09645ea6e4e1f5375f7596b73b3b597e6507201a"
           }) {
@@ -505,7 +505,7 @@ describe('graphql/queries', () => {
     it('should accept the eventAddress filter', async () => {
       const valid = `
         query {
-          globalLeaderboard(filter: { eventAddress: "0x09645ea6e4e1f5375f7596b73b3b597e6507201a" }) {
+          globalLeaderboardEntries(filter: { eventAddress: "0x09645ea6e4e1f5375f7596b73b3b597e6507201a" }) {
             ${PAGINATED_LEADERBOARD}
           }
         }
@@ -516,7 +516,7 @@ describe('graphql/queries', () => {
     it('should accept the userAddress filter', async () => {
       const valid = `
         query {
-          globalLeaderboard(filter: { userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a" }) {
+          globalLeaderboardEntries(filter: { userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a" }) {
             ${PAGINATED_LEADERBOARD}
           }
         }

--- a/test/graphql/queries.tests.js
+++ b/test/graphql/queries.tests.js
@@ -5,6 +5,7 @@ const {
   PAGINATED_BETS,
   PAGINATED_RESULT_SETS,
   PAGINATED_WITHDRAWS,
+  PAGINATED_LEADERBOARD,
 } = require('./schema-helper');
 const schema = require('../../src/graphql/schema');
 
@@ -441,6 +442,82 @@ describe('graphql/queries', () => {
         query {
           withdraws(filter: { winnerAddress: "0xd5d087daabc73fc6cc5d9c1131b93acbd53a2428" }) {
             ${PAGINATED_WITHDRAWS}
+          }
+        }
+      `;
+      tester.test(true, valid);
+    });
+  });
+
+  describe('eventLeaderboard', () => {
+    it('should return the query', async () => {
+      const valid = `
+        query {
+          eventLeaderboard(filter: {
+            userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a",
+            eventAddress:"0x09645ea6e4e1f5375f7596b73b3b597e6507201a"
+          }) {
+            ${PAGINATED_LEADERBOARD}
+          }
+        }
+      `;
+      tester.test(true, valid);
+    });
+
+    it('should accept the eventAddress filter', async () => {
+      const valid = `
+        query {
+          eventLeaderboard(filter: { eventAddress: "0x09645ea6e4e1f5375f7596b73b3b597e6507201a" }) {
+            ${PAGINATED_LEADERBOARD}
+          }
+        }
+      `;
+      tester.test(true, valid);
+    });
+
+    it('should accept the userAddress filter', async () => {
+      const valid = `
+        query {
+          eventLeaderboard(filter: { userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a" }) {
+            ${PAGINATED_LEADERBOARD}
+          }
+        }
+      `;
+      tester.test(true, valid);
+    });
+  });
+
+  describe('globalLeaderboard', () => {
+    it('should return the query', async () => {
+      const valid = `
+        query {
+          globalLeaderboard(filter: {
+            userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a",
+            eventAddress:"0x09645ea6e4e1f5375f7596b73b3b597e6507201a"
+          }) {
+            ${PAGINATED_LEADERBOARD}
+          }
+        }
+      `;
+      tester.test(true, valid);
+    });
+
+    it('should accept the eventAddress filter', async () => {
+      const valid = `
+        query {
+          globalLeaderboard(filter: { eventAddress: "0x09645ea6e4e1f5375f7596b73b3b597e6507201a" }) {
+            ${PAGINATED_LEADERBOARD}
+          }
+        }
+      `;
+      tester.test(true, valid);
+    });
+
+    it('should accept the userAddress filter', async () => {
+      const valid = `
+        query {
+          globalLeaderboard(filter: { userAddress:"0x939592864c0bd3355b2d54e4fa2203e8343b6d6a" }) {
+            ${PAGINATED_LEADERBOARD}
           }
         }
       `;

--- a/test/graphql/schema-helper.js
+++ b/test/graphql/schema-helper.js
@@ -141,6 +141,22 @@ const PAGINATED_WITHDRAWS = `
   }
 `;
 
+const LEADERBOARD = `
+  eventAddress
+  userAddress
+  investments
+  winnings
+  returnRatio
+`;
+
+const PAGINATED_LEADERBOARD = `
+  totalCount
+  ${PAGE_INFO}
+  items {
+    ${LEADERBOARD}
+  }
+`;
+
 module.exports = {
   PAGE_INFO,
   BLOCK,
@@ -153,4 +169,5 @@ module.exports = {
   BET,
   RESULT_SET,
   WITHDRAW,
+  PAGINATED_LEADERBOARD,
 };


### PR DESCRIPTION
#267 #265 

- [x] Create eventLeaderboard and globalLeaderboard tables and models

- [x] Make db helper methods for both tables

- [x] In sync, every bet, result set, vote `amounts` goes into eventLeaderboard `investment`

- [x] In sync, when event goes to `WITHDRAWING` status, update `eventLeaderboard winnings and returnRatio`

- [x] In sync,  when event goes to `WITHDRAWING` status, update `globalLeaderboard investments, winnings and returnRatio`

- [x] Migration

- [x] Testings

- [x] Queries